### PR TITLE
use in iframe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ WALDIEZ_STUDIO_BASE_URL=/
 #
 WALDIEZ_STUDIO_HOST=localhost
 WALDIEZ_STUDIO_PORT=8000
+WALDIEZ_STUDIO_MAIN_DOMAIN=waldiez.io
 # comma separated list of trusted hosts
 WALDIEZ_STUDIO_TRUSTED_HOSTS=localhost,*.waldiez.io
 # comma separated list of trusted origins

--- a/tests/middleware/test_extra_headers.py
+++ b/tests/middleware/test_extra_headers.py
@@ -84,7 +84,6 @@ async def test_security_headers_middleware(client: AsyncClient) -> None:
         == "max-age=31556926; includeSubDomains"
     )
     assert response.headers["X-Content-Type-Options"] == "nosniff"
-    assert response.headers["X-Frame-Options"] == "DENY"
     assert response.headers["X-XSS-Protection"] == "1; mode=block"
 
 
@@ -107,7 +106,6 @@ async def test_security_headers_disabled_csp() -> None:
         response = await client.get("/")
 
         assert "Content-Security-Policy" not in response.headers
-        assert response.headers["X-Frame-Options"] == "DENY"
 
 
 @pytest.mark.anyio

--- a/waldiez_studio/config/settings.py
+++ b/waldiez_studio/config/settings.py
@@ -49,6 +49,7 @@ class Settings(BaseSettings):
     host: str = get_default_host()
     port: int = get_default_port()
     domain_name: str = get_default_domain_name()
+    main_domain: str = get_default_domain_name()
     force_ssl: bool = False
     trusted_hosts: str | list[str] = get_trusted_hosts(
         domain_name=domain_name, host=host

--- a/waldiez_studio/main.py
+++ b/waldiez_studio/main.py
@@ -116,6 +116,7 @@ app.add_middleware(GZipMiddleware, minimum_size=1000)
 app.add_middleware(
     ExtraHeadersMiddleware,
     csp=True,
+    main_domain=settings.main_domain,
     exclude_patterns=[
         f"^/{BASE_URL}/docs",
         f"^/{BASE_URL}/openapi.json",


### PR DESCRIPTION
## Description of the Change
Studio is now possible to be used in iframe under the same domain.
## Checklist
- [X] PR only contains one change (considered splitting up PR)
- [X] tests added
- [NA] `CHANGELOG.md` updated (if necessary)
